### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First, make sure the Pico SDK is properly installed and configured:
 
 ```bash
 # Install dependencies
-sudo apt install cmake gcc-arm-none-eabi doxygen libnewlib-arm-none-eabi
+sudo apt install g++ gcc-arm-none-eabi doxygen libnewlib-arm-none-eabi git python3
 git clone --recurse-submodules https://github.com/raspberrypi/pico-sdk.git $HOME/pico-sdk
 
 # Configure environment


### PR DESCRIPTION
Fixes #2

`git`, `python3` and `g++` are usually present on Ubuntu, but to be on the safe side we add them as well.