### PR TITLE
Fix clockid_t compile error

### DIFF
--- a/pico_uart_transport.c
+++ b/pico_uart_transport.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <time.h>
 #include "pico/stdlib.h"
 
 #include <uxr/client/profile/transport/custom/custom_transport.h>


### PR DESCRIPTION
I was having compile errors when running make:
```
/home/will/Desktop/micro-ros-project/micro_ros_raspberrypi_pico_sdk/pico_uart_transport.c:11:19: error: unknown type name 'clockid_t'
   11 | int clock_gettime(clockid_t unused, struct timespec *tp)
      |                   ^~~~~~~~~
make[2]: *** [CMakeFiles/micro-ros-project.dir/build.make:90: CMakeFiles/micro-ros-project.dir/micro_ros_raspberrypi_pico_sdk/pico_uart_transport.c.obj] Error 1
```
I found that I needed to add `#include <time.h>` in `pico_uart_transport.c`. 

I am compiling on a Raspberry Pi 5 running Ubuntu 24.04 LTS with ROS2 Jazzy.