### PR TITLE
Add clone instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ source ~/.bashrc
 
 ### 2. Compile Example
 
-Once the Pico SDK is ready, compile the example:
+Once the Pico SDK is ready, clone this repository and compile the example:
 
 ```bash
+git clone https://github.com/micro-ROS/micro_ros_raspberrypi_pico_sdk
 cd micro_ros_raspberrypi_pico_sdk
 mkdir build
 cd build


### PR DESCRIPTION
Add instructions about cloning this repository on the readme.
Closes https://github.com/micro-ROS/micro_ros_raspberrypi_pico_sdk/issues/958